### PR TITLE
Fix a few bugs

### DIFF
--- a/index-import.cpp
+++ b/index-import.cpp
@@ -247,9 +247,8 @@ int main(int argc, char **argv) {
 
   if (errors) {
     errs() << "Aborting due to " << errors;
-    errs() << " error" << (errors > 1) ? "s"
-                                       : ""
-                                             << ".\n";
+    errs() << " error" << ((errors > 1) ? "s" : "");
+    errs() << ".\n";
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
* Fix a bug where if record subdirectories already existed, it would
  print an error. fs::create_subdirectories() correctly creates all
  intermediate subdirectories and saves the need to check for
  existence.

* Fix a problem where if the regex passed in the command line didn't
  compile, it would crash. Now it properly reports an error.