### PR TITLE
Specific correct min CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 
 find_package(Clang CONFIG REQUIRED)
 


### PR DESCRIPTION
The `target_link_options` function was added in v3.13.

See: https://cmake.org/cmake/help/v3.13/command/target_link_options.html