### PR TITLE
Change tests to support parallel processing

### DIFF
--- a/tests/multiple/expected.txt
+++ b/tests/multiple/expected.txt
@@ -1,14 +1,15 @@
-CHECK: Remapping Index Store at: 'input1' to 'output'
-CHECK: Remapping file input1/v5/units/input1.c.o-2XOJVCVQRKPMV
-CHECK: MainFilePath: input1.c
-CHECK: OutputFile: output1.c.o
-CHECK: WorkingDir: /fake/working/dir
-CHECK: SysrootPath: {{/.*}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk
-CHECK: DependencyFilePath: input1.c
-CHECK: Remapping Index Store at: 'input2' to 'output'
-CHECK: Remapping file input2/v5/units/input2.c.o-1F2C0MY9VWEXX
-CHECK: MainFilePath: input2.c
-CHECK: OutputFile: output2.c.o
-CHECK: WorkingDir: /fake/working/dir
-CHECK: SysrootPath: {{/.*}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk
-CHECK: DependencyFilePath: input2.c
+CHECK-DAG: Remapping Index Store at: 'input1' to 'output'
+CHECK-DAG: Remapping file input1/v5/units/input1.c.o-2XOJVCVQRKPMV
+CHECK-DAG: MainFilePath: input1.c
+CHECK-DAG: OutputFile: output1.c.o
+CHECK-DAG: WorkingDir: /fake/working/dir
+CHECK-DAG: SysrootPath: {{/.*}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk
+CHECK-DAG: DependencyFilePath: input1.c
+
+CHECK-DAG: Remapping Index Store at: 'input2' to 'output'
+CHECK-DAG: Remapping file input2/v5/units/input2.c.o-1F2C0MY9VWEXX
+CHECK-DAG: MainFilePath: input2.c
+CHECK-DAG: OutputFile: output2.c.o
+CHECK-DAG: WorkingDir: /fake/working/dir
+CHECK-DAG: SysrootPath: {{/.*}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk
+CHECK-DAG: DependencyFilePath: input2.c


### PR DESCRIPTION
This is a change to support #24, which improves performance by processing indexes concurrently.

Using the [`CHECK-DAG` directive](https://llvm.org/docs/CommandGuide/FileCheck.html#the-check-dag-directive) ensures the tests still pass, even if the output is interleaved because of concurrency. This change makes the tests pass when run with #24.
