### PR TITLE
CMake: Add project(index-import)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
+if(COMMAND project)
+  project(index-import)
+endif()
 
 find_package(Clang CONFIG REQUIRED)
 


### PR DESCRIPTION
Adds a conditional call to `project()`. In a recent version of CMake, it started to produce the below warning.

```
CMake Warning (dev) in CMakeLists.txt:
  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as

    project(ProjectName)

  near the top of the file, but after cmake_minimum_required().

  CMake is pretending there is a "project(Project)" command on the first
  line.
This warning is for project developers.  Use -Wno-dev to suppress it.
```