### PR TITLE
Fix tests

### DIFF
--- a/tests/clang/expected.txt
+++ b/tests/clang/expected.txt
@@ -1,5 +1,5 @@
 CHECK: Remapping Index Store at: 'input' to 'output'
-CHECK: Remapping file input/v5/units/input.c.o-7GYKMSFATPVS
+CHECK: Remapping file input/v5/units/input.c.o-
 CHECK: MainFilePath: input.c
 CHECK: OutputFile: output.c.o
 CHECK: WorkingDir: /fake/working/dir

--- a/tests/multiple/expected.txt
+++ b/tests/multiple/expected.txt
@@ -1,5 +1,5 @@
 CHECK-DAG: Remapping Index Store at: 'input1' to 'output'
-CHECK-DAG: Remapping file input1/v5/units/input1.c.o-2XOJVCVQRKPMV
+CHECK-DAG: Remapping file input1/v5/units/input1.c.o-
 CHECK-DAG: MainFilePath: input1.c
 CHECK-DAG: OutputFile: output1.c.o
 CHECK-DAG: WorkingDir: /fake/working/dir
@@ -7,7 +7,7 @@ CHECK-DAG: SysrootPath: {{/.*}}/Contents/Developer/Platforms/MacOSX.platform/Dev
 CHECK-DAG: DependencyFilePath: input1.c
 
 CHECK-DAG: Remapping Index Store at: 'input2' to 'output'
-CHECK-DAG: Remapping file input2/v5/units/input2.c.o-1F2C0MY9VWEXX
+CHECK-DAG: Remapping file input2/v5/units/input2.c.o-
 CHECK-DAG: MainFilePath: input2.c
 CHECK-DAG: OutputFile: output2.c.o
 CHECK-DAG: WorkingDir: /fake/working/dir

--- a/tests/swiftc/expected.txt
+++ b/tests/swiftc/expected.txt
@@ -1,5 +1,5 @@
 CHECK: Remapping Index Store at: 'input' to 'output'
-CHECK: Remapping file input/v5/units/input.o-WJTHFC1KVBQ8
+CHECK: Remapping file input/v5/units/input.o-
 CHECK: MainFilePath: /fake/working/dir/input.swift
 CHECK: OutputFile: output.o
 CHECK: WorkingDir: /fake/working/dir


### PR DESCRIPTION
The hashes at the end of index files are computed using absolute paths, if the repository is checked out in a different path, the checksums won't match. Since it's not necessary for the tests to check this checksum, just ignore it.