### PR TITLE
Remap source/target paths for includes

### DIFF
--- a/index-import.cpp
+++ b/index-import.cpp
@@ -176,8 +176,8 @@ static IndexUnitWriter remapUnit(const std::unique_ptr<IndexUnitReader> &reader,
     const auto sourcePath = remapper.remap(info.SourcePath);
     const auto targetPath = remapper.remap(info.TargetPath);
     if (Verbose) {
-      *outs << "SourcePath: " << sourcePath << "\n"
-            << "TargetPath: " << targetPath << "\n";
+      *outs << "Include SourcePath: " << sourcePath << "\n"
+            << "Include TargetPath: " << targetPath << "\n";
     }
 
     // Note this isn't relevant to Swift.

--- a/index-import.cpp
+++ b/index-import.cpp
@@ -176,8 +176,8 @@ static IndexUnitWriter remapUnit(const std::unique_ptr<IndexUnitReader> &reader,
     const auto sourcePath = remapper.remap(info.SourcePath);
     const auto targetPath = remapper.remap(info.TargetPath);
     if (Verbose) {
-      *outs << "Include SourcePath: " << sourcePath << "\n"
-            << "Include TargetPath: " << targetPath << "\n";
+      *outs << "IncludeSourcePath: " << sourcePath << "\n"
+            << "IncludeTargetPath: " << targetPath << "\n";
     }
 
     // Note this isn't relevant to Swift.

--- a/index-import.cpp
+++ b/index-import.cpp
@@ -175,6 +175,10 @@ static IndexUnitWriter remapUnit(const std::unique_ptr<IndexUnitReader> &reader,
   reader->foreachInclude([&](const IndexUnitReader::IncludeInfo &info) {
     const auto sourcePath = remapper.remap(info.SourcePath);
     const auto targetPath = remapper.remap(info.TargetPath);
+    if (Verbose) {
+      *outs << "SourcePath: " << sourcePath << "\n"
+            << "TargetPath: " << targetPath << "\n";
+    }
 
     // Note this isn't relevant to Swift.
     writer.addInclude(fileMgr.getFile(sourcePath), info.SourceLine,

--- a/index-import.cpp
+++ b/index-import.cpp
@@ -173,9 +173,12 @@ static IndexUnitWriter remapUnit(const std::unique_ptr<IndexUnitReader> &reader,
   });
 
   reader->foreachInclude([&](const IndexUnitReader::IncludeInfo &info) {
+    const auto sourcePath = remapper.remap(info.SourcePath);
+    const auto targetPath = remapper.remap(info.TargetPath);
+
     // Note this isn't revelevnt to Swift.
-    writer.addInclude(fileMgr.getFile(info.SourcePath), info.SourceLine,
-                      fileMgr.getFile(info.TargetPath));
+    writer.addInclude(fileMgr.getFile(sourcePath), info.SourceLine,
+                      fileMgr.getFile(targetPath));
     return true;
   });
 

--- a/index-import.cpp
+++ b/index-import.cpp
@@ -176,7 +176,7 @@ static IndexUnitWriter remapUnit(const std::unique_ptr<IndexUnitReader> &reader,
     const auto sourcePath = remapper.remap(info.SourcePath);
     const auto targetPath = remapper.remap(info.TargetPath);
 
-    // Note this isn't revelevnt to Swift.
+    // Note this isn't relevant to Swift.
     writer.addInclude(fileMgr.getFile(sourcePath), info.SourceLine,
                       fileMgr.getFile(targetPath));
     return true;


### PR DESCRIPTION
Apply the remappings to the source/target paths for each `#include` as well. This is relevant to C/C++/ObjC sources and not Swift.

The goal of this change was to allow Xcode to correctly resolve `#include` statements from a remapped index that originated from Bazel. This change doesn't fully fix that but is part of the solution.