### PR TITLE
Remove verbose output mode

### DIFF
--- a/tests/clang/expected.txt
+++ b/tests/clang/expected.txt
@@ -1,7 +1,19 @@
-CHECK: Remapping Index Store at: 'input' to 'output'
-CHECK: Remapping file input/v5/units/input.c.o-
-CHECK: MainFilePath: input.c
+CHECK: ---
+CHECK: # output/v5/units/output.c.o-{{.+}}
+CHECK: WorkingDirectory: /fake/working/dir
+CHECK: MainFilePath: 
 CHECK: OutputFile: output.c.o
-CHECK: WorkingDir: /fake/working/dir
-CHECK: SysrootPath: {{/.*}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.{{[0-9]+}}.sdk
-CHECK: DependencyFilePath: input.c
+CHECK: ModuleName: 
+CHECK: IsSystemUnit: 0
+CHECK: IsModuleUnit: 0
+CHECK: IsDebugCompilation: 1
+CHECK: CompilationTarget: x86_64-apple-macosx10.{{.+}}
+CHECK: SysrootPath: {{.+}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX{{.*}}.sdk
+CHECK: ProviderIdentifier: clang
+CHECK: ProviderVersion: {{.+}}
+CHECK: Dependencies:
+CHECK: 	DependencyKind: Record
+CHECK: 	IsSystem: 0
+CHECK: 	UnitOrRecordName: input.c-1GAVGMEKRGFCS
+CHECK: 	FilePath: input.c
+CHECK: 	ModuleName: 

--- a/tests/multiple/expected.txt
+++ b/tests/multiple/expected.txt
@@ -1,15 +1,38 @@
-CHECK-DAG: Remapping Index Store at: 'input1' to 'output'
-CHECK-DAG: Remapping file input1/v5/units/input1.c.o-
-CHECK-DAG: MainFilePath: input1.c
-CHECK-DAG: OutputFile: output1.c.o
-CHECK-DAG: WorkingDir: /fake/working/dir
-CHECK-DAG: SysrootPath: {{/.*}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.{{[0-9]+}}.sdk
-CHECK-DAG: DependencyFilePath: input1.c
-
-CHECK-DAG: Remapping Index Store at: 'input2' to 'output'
-CHECK-DAG: Remapping file input2/v5/units/input2.c.o-
-CHECK-DAG: MainFilePath: input2.c
-CHECK-DAG: OutputFile: output2.c.o
-CHECK-DAG: WorkingDir: /fake/working/dir
-CHECK-DAG: SysrootPath: {{/.*}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.{{[0-9]+}}.sdk
-CHECK-DAG: DependencyFilePath: input2.c
+CHECK: ---
+CHECK: # output/v5/units/output1.c.o-{{.+}}
+CHECK: WorkingDirectory: /fake/working/dir
+CHECK: MainFilePath: 
+CHECK: OutputFile: output1.c.o
+CHECK: ModuleName: 
+CHECK: IsSystemUnit: 0
+CHECK: IsModuleUnit: 0
+CHECK: IsDebugCompilation: 1
+CHECK: CompilationTarget: x86_64-apple-macosx10.{{.+}}
+CHECK: SysrootPath: {{.+}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX{{.+}}.sdk
+CHECK: ProviderIdentifier: clang
+CHECK: ProviderVersion: {{.+}}
+CHECK: Dependencies:
+CHECK: 	DependencyKind: Record
+CHECK: 	IsSystem: 0
+CHECK: 	UnitOrRecordName: input1.c-25D1KZY099GN2
+CHECK: 	FilePath: input1.c
+CHECK: 	ModuleName: 
+CHECK: ---
+CHECK: # output/v5/units/output2.c.o-{{.+}}
+CHECK: WorkingDirectory: /fake/working/dir
+CHECK: MainFilePath: 
+CHECK: OutputFile: output2.c.o
+CHECK: ModuleName: 
+CHECK: IsSystemUnit: 0
+CHECK: IsModuleUnit: 0
+CHECK: IsDebugCompilation: 1
+CHECK: CompilationTarget: x86_64-apple-macosx10.{{.+}}
+CHECK: SysrootPath: {{.+}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX{{.+}}.sdk
+CHECK: ProviderIdentifier: clang
+CHECK: ProviderVersion: {{.+}}
+CHECK: Dependencies:
+CHECK: 	DependencyKind: Record
+CHECK: 	IsSystem: 0
+CHECK: 	UnitOrRecordName: input2.c-1F2N5TQ6O2TRL
+CHECK: 	FilePath: input2.c
+CHECK: 	ModuleName: 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -19,12 +19,13 @@ rm -fr input output
 # Produce the index.
 clang -fsyntax-only -index-store-path input input.c
 
-# Test index-import by matching its verbose output.
-# See https://llvm.org/docs/CommandGuide/FileCheck.html
-../../build/index-import -V \
+../../build/index-import \
   -remap input.c.o=output.c.o \
   -remap "$(pwd)"=/fake/working/dir \
-  input output \
+  input output
+
+# See https://llvm.org/docs/CommandGuide/FileCheck.html
+../../build/absolute-unit output/v5/units/* \
   | FileCheck expected.txt
 
 # Check that the expected index files exist.
@@ -48,12 +49,13 @@ rm -fr input output
 # Produce the index and delete the unneeded .o.
 xcrun swiftc -index-store-path input -c input.swift && rm input.o
 
-# Test index-import by matching its verbose output.
-# See https://llvm.org/docs/CommandGuide/FileCheck.html
-../../build/index-import -V \
+../../build/index-import \
   -remap input.o=output.o \
   -remap "$(pwd)"=/fake/working/dir \
-  input output \
+  input output
+
+# See https://llvm.org/docs/CommandGuide/FileCheck.html
+../../build/absolute-unit output/v5/units/* \
   | FileCheck expected.txt
 
 # Check that the expected index files exist.
@@ -78,13 +80,14 @@ rm -fr input1 input2 output
 clang -fsyntax-only -index-store-path input1 input1.c
 clang -fsyntax-only -index-store-path input2 input2.c
 
-# Test index-import by matching its verbose output.
-# See https://llvm.org/docs/CommandGuide/FileCheck.html
-../../build/index-import -V \
+../../build/index-import \
   -parallel-stride 1 \
   -remap 'input(.).c.o=output$1.c.o' \
   -remap "$(pwd)"=/fake/working/dir \
-  input1 input2 output \
+  input1 input2 output
+
+# See https://llvm.org/docs/CommandGuide/FileCheck.html
+../../build/absolute-unit output/v5/units/* \
   | FileCheck expected.txt
 
 # Check that the expected index files exist.

--- a/tests/swiftc/expected.txt
+++ b/tests/swiftc/expected.txt
@@ -1,7 +1,43 @@
-CHECK: Remapping Index Store at: 'input' to 'output'
-CHECK: Remapping file input/v5/units/input.o-
-CHECK: MainFilePath: /fake/working/dir/input.swift
+CHECK: ---
+CHECK: # output/v5/units/output.o-{{.+}}
+CHECK: WorkingDirectory: /fake/working/dir
+CHECK: MainFilePath: 
 CHECK: OutputFile: output.o
-CHECK: WorkingDir: /fake/working/dir
-CHECK: SysrootPath: {{/.*}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.{{[0-9]+}}.sdk
-CHECK: DependencyFilePath: {{/.*}}/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/{{[^/]+}}/Swift.swiftmodule
+CHECK: ModuleName: input
+CHECK: IsSystemUnit: 0
+CHECK: IsModuleUnit: 0
+CHECK: IsDebugCompilation: 1
+CHECK: CompilationTarget: x86_64-apple-macosx10.{{.+}}
+CHECK: SysrootPath: {{.+}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX{{.*}}.sdk
+CHECK: ProviderIdentifier: swift
+CHECK: ProviderVersion: 
+CHECK: Dependencies:
+CHECK: 	DependencyKind: Unit
+CHECK: 	IsSystem: 1
+CHECK: 	UnitOrRecordName: x86_64-apple-macos.swiftmodule-{{.+}}
+CHECK: 	FilePath: {{.+}}/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/prebuilt-modules/Swift.swiftmodule/x86_64-apple-macos.swiftmodule
+CHECK: 	ModuleName: Swift
+CHECK: 	DependencyKind: Record
+CHECK: 	IsSystem: 0
+CHECK: 	UnitOrRecordName: input.swift-{{.+}}
+CHECK: 	FilePath: /fake/working/dir/input.swift
+CHECK: 	ModuleName: 
+CHECK: ---
+CHECK: # output/v5/units/x86_64-apple-macos.swiftmodule-{{.+}}
+CHECK: WorkingDirectory: /fake/working/dir
+CHECK: MainFilePath: 
+CHECK: OutputFile: {{.+}}/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/prebuilt-modules/Swift.swiftmodule/x86_64-apple-macos.swiftmodule
+CHECK: ModuleName: Swift
+CHECK: IsSystemUnit: 1
+CHECK: IsModuleUnit: 1
+CHECK: IsDebugCompilation: 1
+CHECK: CompilationTarget: x86_64-apple-macosx10.{{.+}}
+CHECK: SysrootPath: {{.+}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX{{.+}}.sdk
+CHECK: ProviderIdentifier: swift
+CHECK: ProviderVersion: 
+CHECK: Dependencies:
+CHECK: 	DependencyKind: Record
+CHECK: 	IsSystem: 1
+CHECK: 	UnitOrRecordName: x86_64-apple-macos.swiftmodule-{{.+}}
+CHECK: 	FilePath: {{.+}}/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/prebuilt-modules/Swift.swiftmodule/x86_64-apple-macos.swiftmodule
+CHECK: 	ModuleName: Swift


### PR DESCRIPTION
Instead of having a verbose mode, #37 introduced a tool for printing unit files as text ("`absolute-unit`"). With that tool, unit files can be inspected before and after remapping, and also print all unit fields, not just the path fields.

This change removes the `-verbose`/`-V` flags. The tests now use `absolute-unit` when verifying their contents.
