### PR TITLE
Indicate list items in absolute-unit output

### DIFF
--- a/absolute-unit.cpp
+++ b/absolute-unit.cpp
@@ -18,6 +18,8 @@ static const char *_dependencyKindName(IndexUnitReader::DependencyKind kind) {
   }
 }
 
+#define INDENT "    "
+
 int main(int argc, char **argv) {
   cl::ParseCommandLineOptions(argc, argv);
 
@@ -53,11 +55,11 @@ int main(int argc, char **argv) {
         needsHeader = false;
       }
 
-      outs() << "\t- DependencyKind: " << _dependencyKindName(info.Kind) << "\n"
-             << "\t  IsSystem: " << info.IsSystem << "\n"
-             << "\t  UnitOrRecordName: " << info.UnitOrRecordName << "\n"
-             << "\t  FilePath: " << info.FilePath << "\n"
-             << "\t  ModuleName: " << info.ModuleName << "\n";
+      outs() << INDENT "- DependencyKind: " << _dependencyKindName(info.Kind) << "\n"
+             << INDENT "  IsSystem: " << info.IsSystem << "\n"
+             << INDENT "  UnitOrRecordName: " << info.UnitOrRecordName << "\n"
+             << INDENT "  FilePath: " << info.FilePath << "\n"
+             << INDENT "  ModuleName: " << info.ModuleName << "\n";
       return true;
     });
 
@@ -68,9 +70,9 @@ int main(int argc, char **argv) {
         needsHeader = false;
       }
 
-      outs() << "\t- SourcePath: " << info.SourcePath << "\n"
-             << "\t  SourceLine: " << info.SourceLine << "\n"
-             << "\t  TargetPath: " << info.TargetPath << "\n";
+      outs() << INDENT "- SourcePath: " << info.SourcePath << "\n"
+             << INDENT "  SourceLine: " << info.SourceLine << "\n"
+             << INDENT "  TargetPath: " << info.TargetPath << "\n";
       return true;
     });
   }

--- a/absolute-unit.cpp
+++ b/absolute-unit.cpp
@@ -53,11 +53,11 @@ int main(int argc, char **argv) {
         needsHeader = false;
       }
 
-      outs() << "\tDependencyKind: " << _dependencyKindName(info.Kind) << "\n"
-             << "\tIsSystem: " << info.IsSystem << "\n"
-             << "\tUnitOrRecordName: " << info.UnitOrRecordName << "\n"
-             << "\tFilePath: " << info.FilePath << "\n"
-             << "\tModuleName: " << info.ModuleName << "\n";
+      outs() << "\t- DependencyKind: " << _dependencyKindName(info.Kind) << "\n"
+             << "\t  IsSystem: " << info.IsSystem << "\n"
+             << "\t  UnitOrRecordName: " << info.UnitOrRecordName << "\n"
+             << "\t  FilePath: " << info.FilePath << "\n"
+             << "\t  ModuleName: " << info.ModuleName << "\n";
       return true;
     });
 
@@ -68,9 +68,9 @@ int main(int argc, char **argv) {
         needsHeader = false;
       }
 
-      outs() << "\tSourcePath: " << info.SourcePath << "\n"
-             << "\tSourceLine: " << info.SourceLine << "\n"
-             << "\tTargetPath: " << info.TargetPath << "\n";
+      outs() << "\t- SourcePath: " << info.SourcePath << "\n"
+             << "\t  SourceLine: " << info.SourceLine << "\n"
+             << "\t  TargetPath: " << info.TargetPath << "\n";
       return true;
     });
   }


### PR DESCRIPTION
The output of `absolute-unit` is intended to be yaml (or close enough). A unit's dependencies are a list, so this adds a `-` marker to the start of each dependency block. Same for unit includes.