### PR TITLE
Add initial validate-index tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,12 @@ function(add_index_executable execname)
   if(NOT LLVM_ENABLE_RTTI)
     target_compile_options("${execname}" PRIVATE -fno-rtti)
   endif()
-  target_link_libraries("${execname}" PRIVATE clangIndex)
+  target_link_libraries("${execname}" PRIVATE clangIndex clangIndexDataStore)
   target_link_options("${execname}" PRIVATE -dead_strip)
 endfunction()
 
 add_index_executable(index-import)
 add_index_executable(absolute-unit)
+add_index_executable(validate-index)
+# clangIndexDataStore depends on clangDirectoryWatcher which depends on CoreServices
+target_link_options(validate-index PRIVATE -framework CoreServices)

--- a/validate-index.cpp
+++ b/validate-index.cpp
@@ -15,7 +15,7 @@ static cl::opt<std::string> IndexStore(cl::Positional, cl::Required,
                                        cl::desc("<indexstore>"));
 
 // Helper function to use consistent output. Uses `stdout` to ensure the output
-// is greppable, or redirectable to file (separate tool errors).
+// is greppable, or redirectable to file (separate from API/system errors).
 static void logMissingFile(StringRef unitName, StringRef key, StringRef path) {
   outs() << unitName << ": " << key << ": " << path << "\n";
 }

--- a/validate-index.cpp
+++ b/validate-index.cpp
@@ -1,0 +1,74 @@
+#include "clang/Index/IndexDataStore.h"
+#include "clang/Index/IndexUnitReader.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileSystem.h"
+
+#include <utility>
+#include <string>
+#include <vector>
+
+using namespace llvm;
+using namespace llvm::sys;
+using namespace clang::index;
+
+static cl::opt<std::string> IndexStore(cl::Positional, cl::Required,
+                                       cl::desc("<indexstore>"));
+
+int main(int argc, char **argv) {
+  cl::ParseCommandLineOptions(argc, argv);
+
+  std::string storeError{};
+  auto store = IndexDataStore::create(IndexStore, storeError);
+  if (not store) {
+    errs() << "error: failed to open indexstore " << IndexStore << " -- "
+           << storeError << "\n";
+    return EXIT_FAILURE;
+  }
+
+  std::vector<std::string> unitNames{};
+  store->foreachUnitName(false, [&](StringRef unitName) {
+    unitNames.push_back(unitName.str());
+    return true;
+  });
+
+  auto exitStatus = EXIT_SUCCESS;
+  for (const auto &unitName : unitNames) {
+    std::string readerError;
+    auto reader = IndexUnitReader::createWithUnitFilename(unitName, IndexStore,
+                                                          readerError);
+    if (not reader) {
+      errs() << "error: failed to read unit file " << unitName << " -- "
+             << readerError << "\n";
+      return EXIT_FAILURE;
+    }
+
+    const std::vector<std::pair<std::string, std::string>> unitPaths = {
+        {"WorkingDirectory", reader->getWorkingDirectory()},
+        {"MainFilePath", reader->getMainFilePath()},
+        {"OutputFile", reader->getOutputFile()},
+        {"SysrootPath", reader->getSysrootPath()},
+    };
+
+    for (const auto &pair : unitPaths) {
+      const auto &key = pair.first;
+      const auto &path = pair.second;
+      if (path.empty()) {
+        continue;
+      }
+
+      if (not fs::exists(path)) {
+        exitStatus = EXIT_FAILURE;
+        outs() << unitName << ": " << key << ": " << path << "\n";
+      }
+    }
+
+    reader->foreachDependency([&](const IndexUnitReader::DependencyInfo &info) {
+      if (not fs::exists(info.FilePath)) {
+        outs() << unitName << ": DependencyPath: " << info.FilePath << "\n";
+      }
+      return true;
+    });
+  }
+
+  return exitStatus;
+}

--- a/validate-index.cpp
+++ b/validate-index.cpp
@@ -43,9 +43,10 @@ int main(int argc, char **argv) {
     auto reader = IndexUnitReader::createWithUnitFilename(unitName, IndexStore,
                                                           readerError);
     if (not reader) {
+      exitStatus = EXIT_FAILURE;
       errs() << "error: failed to read unit file " << unitName << " -- "
              << readerError << "\n";
-      return EXIT_FAILURE;
+      continue;
     }
 
     const std::vector<std::pair<std::string, std::string>> unitPaths = {

--- a/validate-index.cpp
+++ b/validate-index.cpp
@@ -3,8 +3,8 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
 
-#include <utility>
 #include <string>
+#include <utility>
 #include <vector>
 
 using namespace llvm;
@@ -45,7 +45,10 @@ int main(int argc, char **argv) {
     const std::vector<std::pair<std::string, std::string>> unitPaths = {
         {"WorkingDirectory", reader->getWorkingDirectory()},
         {"MainFilePath", reader->getMainFilePath()},
-        {"OutputFile", reader->getOutputFile()},
+        // TODO: OutputFile does not need to exist, but its path needs to match
+        // the format expected by Xcode. Check the format instead of the
+        // existence of the file.
+        // {"OutputFile", reader->getOutputFile()},
         {"SysrootPath", reader->getSysrootPath()},
     };
 

--- a/validate-index.cpp
+++ b/validate-index.cpp
@@ -43,13 +43,13 @@ int main(int argc, char **argv) {
     }
 
     const std::vector<std::pair<std::string, std::string>> unitPaths = {
-        {"WorkingDirectory", reader->getWorkingDirectory()},
         {"MainFilePath", reader->getMainFilePath()},
+        {"SysrootPath", reader->getSysrootPath()},
+        {"WorkingDirectory", reader->getWorkingDirectory()},
         // TODO: OutputFile does not need to exist, but its path needs to match
         // the format expected by Xcode. Check the format instead of the
         // existence of the file.
         // {"OutputFile", reader->getOutputFile()},
-        {"SysrootPath", reader->getSysrootPath()},
     };
 
     for (const auto &pair : unitPaths) {

--- a/validate-index.cpp
+++ b/validate-index.cpp
@@ -72,6 +72,20 @@ int main(int argc, char **argv) {
       }
       return true;
     });
+
+    reader->foreachInclude([&](const IndexUnitReader::IncludeInfo &info) {
+      if (not fs::exists(info.SourcePath)) {
+        exitStatus = EXIT_FAILURE;
+        outs() << unitName << ": IncludeSourcePath: " << info.SourcePath
+               << "\n";
+      }
+      if (not fs::exists(info.TargetPath)) {
+        exitStatus = EXIT_FAILURE;
+        outs() << unitName << ": IncludeTargetPath: " << info.TargetPath
+               << "\n";
+      }
+      return true;
+    });
   }
 
   return exitStatus;

--- a/validate-index.cpp
+++ b/validate-index.cpp
@@ -67,6 +67,7 @@ int main(int argc, char **argv) {
 
     reader->foreachDependency([&](const IndexUnitReader::DependencyInfo &info) {
       if (not fs::exists(info.FilePath)) {
+        exitStatus = EXIT_FAILURE;
         outs() << unitName << ": DependencyPath: " << info.FilePath << "\n";
       }
       return true;


### PR DESCRIPTION
This adds `validate-index`, a tool to validate indexstore unit files. Currently it checks that paths exist. This is useful as a post-import step, to confirm that `index-import` produced valid paths.

Further updates may include:

1. Validating the format of `OutputFile`'s path
2. Validation of unit/record names
3. Correction of sysroot