### PR TITLE
Update bazel example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ index-import \
     -remap "$bazel_module=$xcode_module" \
     -remap "$bazel_swift_object=$xcode_object" \
     -remap "$bazel_root=$SRCROOT" \
-    path/to/input/index \
-    path/to/xcode/index
+    "$SRCROOT/bazel-out/<config>/bin/<package>/<module>.indexstore" \
+    "$HOME/Library/Developer/Xcode/DerivedData/<project>/Index/DataStore"
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ bazel_swift_object="$bazel_bin/.*/(.+?)_objs/.*/(.+?)\\.swift\\.o$"
 xcode_object="$CONFIGURATION_TEMP_DIR/\$1.build/Objects-normal/$ARCHS/\$2.o"
 
 # ex: $bazel_bin/<package>/<module>.swiftmodule
-readonly bazel_module="$bazel_bin/.*/(.+?)\\.swiftmodule$"
+bazel_module="$bazel_bin/.*/(.+?)\\.swiftmodule$"
 # ex: Build/Products/Debug-iphonesimulator/<module>.swiftmodule/x86_64.swiftmodule
-readonly xcode_module="$BUILT_PRODUCTS_DIR/\$1.swiftmodule/$ARCHS.swiftmodule"
+xcode_module="$BUILT_PRODUCTS_DIR/\$1.swiftmodule/$ARCHS.swiftmodule"
 
 index-import \
     -remap "$bazel_module=$xcode_module" \


### PR DESCRIPTION
It was pointed out by @indragiek that the bazel example contained `/Modules/` in the path, which he wasn't seeing in his `bazel-out`. That path was specific to a project, so I've updated the README to be more generic.

This update is taken somewhat from [bazel-xcode-demo-swift-driver](https://github.com/kastiglione/bazel-xcode-demo-swift-driver/blob/9336d63e5b49792fee5cc7f317b144855b6226cb/bazel/installers/_indexstore.sh).