### PR TITLE
Small simplifications to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,10 @@ function(add_index_executable execname)
   if(NOT LLVM_ENABLE_RTTI)
     target_compile_options("${execname}" PRIVATE -fno-rtti)
   endif()
-  target_link_libraries("${execname}" PRIVATE clangIndex clangIndexDataStore)
+  target_link_libraries("${execname}" PRIVATE clangIndexDataStore)
   target_link_options("${execname}" PRIVATE -dead_strip)
 endfunction()
 
 add_index_executable(index-import)
 add_index_executable(absolute-unit)
 add_index_executable(validate-index)
-# clangIndexDataStore depends on clangDirectoryWatcher which depends on CoreServices
-target_link_options(validate-index PRIVATE -framework CoreServices)


### PR DESCRIPTION
1. `clangIndexDataStore` depends on `clangIndex`, the latter doesn't need to be an explicit link dependency
2. The interface of the `clangDirectoryWatcher` target includes the `CoreServices` link options, and doesn't need to be explicit