### PR TITLE
Add the ability to not remap unit files

### DIFF
--- a/index-import.cpp
+++ b/index-import.cpp
@@ -24,7 +24,7 @@ using namespace clang;
 using namespace clang::index;
 using namespace clang::index::writer;
 
-static cl::list<std::string> PathRemaps("remap", cl::OneOrMore,
+static cl::list<std::string> PathRemaps("remap",
                                         cl::desc("Path remapping substitution"),
                                         cl::value_desc("regex=replacement"));
 static cl::alias PathRemapsAlias("r", cl::aliasopt(PathRemaps));


### PR DESCRIPTION
I'd like to have the ability to copy unit files without
remapping them. For this PR https://github.com/lyft/index-import/pull/53
we still need to read in the unit files but not mutate the material.
This PR just removes the requirement on "remap" arg.